### PR TITLE
fix(backend): Resolve TypeScript build error in payment controller

### DIFF
--- a/backend/src/controllers/paymentController.ts
+++ b/backend/src/controllers/paymentController.ts
@@ -50,7 +50,7 @@ export const createPayment = async (req: Request, res: Response) => {
 
     const newPayment = await payment.save();
 
-    invoice.payments.push(newPayment._id);
+    invoice.payments.push(newPayment._id as Types.ObjectId);
     await invoice.save();
 
     await updateInvoiceStatus(invoiceId);

--- a/backend/src/models/invoice.ts
+++ b/backend/src/models/invoice.ts
@@ -1,11 +1,11 @@
-import { Schema, model, Document } from 'mongoose';
+import { Schema, model, Document, Types } from 'mongoose';
 import { GstType, InvoiceStatus } from '../types';
 
 export interface IInvoice extends Document {
   invoiceNumber: number;
   date: string;
-  customer: Schema.Types.ObjectId;
-  lorryReceipts: Schema.Types.ObjectId[];
+  customer: Types.ObjectId;
+  lorryReceipts: Types.ObjectId[];
   totalAmount: number;
   remarks: string;
   gstType: GstType;
@@ -19,7 +19,7 @@ export interface IInvoice extends Document {
   isRcm: boolean;
   isManualGst: boolean;
   status: InvoiceStatus;
-  payments: Schema.Types.ObjectId[];
+  payments: Types.ObjectId[];
   dueDate?: string;
 }
 


### PR DESCRIPTION
The build was failing with a TypeScript error in `paymentController.ts`: `Argument of type 'unknown' is not assignable to parameter of type 'ObjectId'`.

This was caused by a type inconsistency between the Mongoose Document `_id` property (typed as `any`) and the strictly typed `IInvoice` interface.

The fix involves two parts:
1. Explicitly casting `newPayment._id` to `Types.ObjectId` in `paymentController.ts`.
2. Updating the `IInvoice` interface in `invoice.ts` to consistently use `Types.ObjectId` instead of `Schema.Types.ObjectId`.

These changes align the types and resolve the build error.