### PR TITLE
fix: resolve invoice save error and verify forms

### DIFF
--- a/components/InvoiceForm.tsx
+++ b/components/InvoiceForm.tsx
@@ -158,7 +158,14 @@ export const InvoiceForm: React.FC<InvoiceFormProps> = ({ onSave, onCancel, avai
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (validate()) {
-      onSave(invoice);
+      // Create a copy of the invoice object for saving
+      // This ensures we don't mutate the state directly
+      // And we can format the lorryReceipts to just be their IDs if needed by the backend
+      const invoiceToSave = {
+        ...invoice,
+        lorryReceipts: (invoice.lorryReceipts || []).map(lr => ({ _id: lr._id })),
+      };
+      onSave(invoiceToSave as Partial<Invoice>);
     }
   };
   


### PR DESCRIPTION
This commit fixes a bug that prevented invoices from being saved. The `InvoiceForm` was sending an array of fully populated Lorry Receipt objects, which caused a backend validation error. The form has been updated to send only the necessary `_id` for each Lorry Receipt.

Additionally, the save functionality for the Client and Truck Hiring Note forms has been reviewed and verified to be working correctly.