### PR TITLE
fix: drop legacy unique index on invoices collection

### DIFF
--- a/backend/src/config/database.ts
+++ b/backend/src/config/database.ts
@@ -19,7 +19,18 @@ const connectDB = async () => {
         console.log('Successfully dropped legacy index "id_1" from lorryreceipts collection.');
       }
     } catch (indexError) {
-        console.error('Could not drop legacy index. This might be okay if it was already removed.', indexError);
+        console.error('Could not drop legacy index from lorryreceipts. This might be okay if it was already removed.', indexError);
+    }
+
+    try {
+      const invoicesCollection = conn.connection.collection('invoices');
+      const indexExists = await invoicesCollection.indexExists('id_1');
+      if (indexExists) {
+        await invoicesCollection.dropIndex('id_1');
+        console.log('Successfully dropped legacy index "id_1" from invoices collection.');
+      }
+    } catch (indexError) {
+        console.error('Could not drop legacy index from invoices. This might be okay if it was already removed.', indexError);
     }
 
   } catch (error) {


### PR DESCRIPTION
This commit resolves an E11000 duplicate key error that occurred when saving invoices. The error was caused by a legacy unique index on the `id` field in the `invoices` collection.

A one-time script has been added to the database connection logic to automatically drop this incorrect index upon server startup, mirroring the fix previously applied to the `lorryreceipts` collection.