### PR TITLE
fix: resolve multiple backend build errors

### DIFF
--- a/backend/src/controllers/paymentController.ts
+++ b/backend/src/controllers/paymentController.ts
@@ -46,14 +46,14 @@ export const createPayment = async (req: Request, res: Response) => {
     if (invoiceId) {
       const invoice = await Invoice.findById(invoiceId);
       if (invoice) {
-        invoice.payments.push(newPayment._id as Types.ObjectId);
+        invoice.payments.push(newPayment._id);
         await invoice.save();
         await updateInvoiceStatus(invoiceId);
       }
     } else if (truckHiringNoteId) {
       const thn = await TruckHiringNote.findById(truckHiringNoteId);
       if (thn) {
-        thn.payments.push(newPayment._id as Types.ObjectId);
+        thn.payments.push(newPayment._id);
         await thn.save();
         await updateThnStatus(truckHiringNoteId);
       }

--- a/backend/src/models/truckHiringNote.ts
+++ b/backend/src/models/truckHiringNote.ts
@@ -1,5 +1,5 @@
 import { Schema, model, Document } from 'mongoose';
-import { THNStatus } from '../../types';
+import { THNStatus } from '../../types.js';
 
 export interface ITruckHiringNote extends Document {
   thnNumber: number;

--- a/backend/src/utils/thnUtils.ts
+++ b/backend/src/utils/thnUtils.ts
@@ -1,6 +1,6 @@
 import TruckHiringNote from '../models/truckHiringNote';
 import Payment from '../models/payment';
-import { THNStatus } from '../../types';
+import { THNStatus } from '../../types.js';
 
 export const updateThnStatus = async (thnId: string) => {
   try {


### PR DESCRIPTION
This commit fixes several TypeScript compilation errors that were causing the backend deployment on Render to fail.

- Resolves `Cannot find module '../../types'` by correcting the import path to `../../types.js` in `truckHiringNote.ts` and `thnUtils.ts`.
- Resolves `TS2345: Argument of type 'mongoose.Types.ObjectId' is not assignable...` by removing an unnecessary type assertion in `paymentController.ts`.