### PR TITLE
fix: resolve final backend build errors

### DIFF
--- a/backend/src/controllers/paymentController.ts
+++ b/backend/src/controllers/paymentController.ts
@@ -46,14 +46,14 @@ export const createPayment = async (req: Request, res: Response) => {
     if (invoiceId) {
       const invoice = await Invoice.findById(invoiceId);
       if (invoice) {
-        invoice.payments.push(newPayment._id);
+        invoice.payments.push(newPayment._id as any);
         await invoice.save();
         await updateInvoiceStatus(invoiceId);
       }
     } else if (truckHiringNoteId) {
       const thn = await TruckHiringNote.findById(truckHiringNoteId);
       if (thn) {
-        thn.payments.push(newPayment._id);
+        thn.payments.push(newPayment._id as any);
         await thn.save();
         await updateThnStatus(truckHiringNoteId);
       }

--- a/backend/src/models/truckHiringNote.ts
+++ b/backend/src/models/truckHiringNote.ts
@@ -1,5 +1,5 @@
 import { Schema, model, Document } from 'mongoose';
-import { THNStatus } from '../../types.js';
+import { THNStatus } from '../../../types';
 
 export interface ITruckHiringNote extends Document {
   thnNumber: number;

--- a/backend/src/utils/thnUtils.ts
+++ b/backend/src/utils/thnUtils.ts
@@ -1,6 +1,6 @@
 import TruckHiringNote from '../models/truckHiringNote';
 import Payment from '../models/payment';
-import { THNStatus } from '../../types.js';
+import { THNStatus } from '../../../types';
 
 export const updateThnStatus = async (thnId: string) => {
   try {


### PR DESCRIPTION
This commit resolves the remaining TypeScript compilation errors that were causing the backend deployment to fail.

- Corrects the relative import path for `types.ts` in the new backend files (`truckHiringNote.ts`, `thnUtils.ts`).
- Fixes a strict type mismatch for Mongoose ObjectIds in `paymentController.ts` by casting the `_id` to `any` before adding it to a related document's payment array.