### PR TITLE
fix: prevent crash from unsafe string replace

### DIFF
--- a/components/ui/Input.tsx
+++ b/components/ui/Input.tsx
@@ -9,7 +9,7 @@ interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
 }
 
 export const Input: React.FC<InputProps> = ({ label, id, type = 'text', error, wrapperClassName, icon, ...props }) => {
-  const inputId = id || `input-${label.replace(/\s+/g, '-')}`;
+  const inputId = id || `input-${(label || '').replace(/\s+/g, '-')}`;
   
   const errorClasses = error 
     ? 'border-red-500 focus:border-red-500 focus:ring-red-500' 

--- a/components/ui/Select.tsx
+++ b/components/ui/Select.tsx
@@ -7,7 +7,7 @@ interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
 }
 
 export const Select: React.FC<SelectProps> = ({ label, id, error, wrapperClassName, children, ...props }) => {
-  const selectId = id || `select-${label.replace(/\s+/g, '-')}`;
+  const selectId = id || `select-${(label || '').replace(/\s+/g, '-')}`;
   
   const errorClasses = error 
     ? 'border-red-500 focus:border-red-500 focus:ring-red-500' 

--- a/components/ui/Textarea.tsx
+++ b/components/ui/Textarea.tsx
@@ -7,7 +7,7 @@ interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement
 }
 
 export const Textarea: React.FC<TextareaProps> = ({ label, id, error, wrapperClassName, ...props }) => {
-  const textareaId = id || `textarea-${label.replace(/\s+/g, '-')}`;
+  const textareaId = id || `textarea-${(label || '').replace(/\s+/g, '-')}`;
   
   const errorClasses = error 
     ? 'border-red-500 focus:border-red-500 focus:ring-red-500' 


### PR DESCRIPTION
This commit fixes a `TypeError: Cannot read properties of undefined (reading 'replace')` that caused the application to show a blank screen after login.

The error was caused by UI components (`Input`, `Select`, `Textarea`) unsafely calling `.replace()` on the `label` prop, which could be undefined.

The fix makes these components more robust by adding a fallback to an empty string, e.g., `(label || '').replace(...)`, preventing the crash.