### PR TITLE
fix: resolve payment history bugs for THNs and Invoices

### DIFF
--- a/components/PaymentHistoryModal.tsx
+++ b/components/PaymentHistoryModal.tsx
@@ -11,7 +11,9 @@ interface PaymentHistoryModalProps {
 }
 
 export const PaymentHistoryModal: React.FC<PaymentHistoryModalProps> = ({ invoice, payments, onClose }) => {
-    const relevantPayments = payments.filter(p => p.invoiceId === invoice._id);
+    // The `payments` prop comes from App.tsx state, which is populated from the backend.
+    // The backend's getPayments call populates `invoiceId`, so `p.invoiceId` is an Invoice object, not a string.
+    const relevantPayments = payments.filter(p => (p.invoiceId as Invoice)?._id === invoice._id);
 
     return (
         <div className="fixed inset-0 bg-black bg-opacity-60 z-50 flex justify-center items-center p-4">


### PR DESCRIPTION
This commit fixes two bugs related to payment history:

1.  A TypeError crash when viewing THN payment history, caused by the backend not populating the payments array. The `truckHiringNoteController` has been updated to include this data.

2.  Invoice payment history not updating on the Dashboard. This was caused by the `PaymentHistoryModal` incorrectly comparing a populated invoice object with a string ID. The filtering logic has been corrected.