### PR TITLE
fix: correct filtering logic in Client Ledger

### DIFF
--- a/components/ClientLedger.tsx
+++ b/components/ClientLedger.tsx
@@ -37,11 +37,11 @@ export const ClientLedger: React.FC<ClientLedgerProps> = ({ customers, invoices,
 
     const customerPayments = payments
       .filter(p => {
-        const invoice = invoices.find(inv => inv._id === p.invoiceId);
-        return invoice?.customer._id === selectedCustomerId;
+        // Since p.invoiceId is populated, it's an object. We need to check its _id.
+        return (p.invoiceId as Invoice)?.customer?._id === selectedCustomerId;
       })
       .map(p => {
-        const invoiceNumber = invoices.find(inv => inv._id === p.invoiceId)?.invoiceNumber;
+        const invoiceNumber = (p.invoiceId as Invoice)?.invoiceNumber;
         const particulars = `Payment for INV-${invoiceNumber} via ${p.mode}${p.referenceNo ? ` (${p.referenceNo})` : ''}${p.notes ? ` - ${p.notes}` : ''}`;
         return {
           type: 'payment' as const,


### PR DESCRIPTION
This commit fixes a bug where the Client Ledger page was not displaying any data. The issue was caused by incorrect filtering logic for payments.

The backend populates the `invoiceId` field on payment objects, turning it into a full Invoice object. The component was incorrectly comparing this object to a string ID, causing the filter to fail.

The logic has been corrected to compare the `_id` of the populated invoice object, which resolves the bug and ensures client transactions are displayed correctly.