### PR TITLE
fix: Restore ledger page and improve PDF titles

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -69,6 +69,12 @@ export const Header: React.FC<HeaderProps> = ({ view, onViewChange, onLogout }) 
             >
               Truck Hiring
             </button>
+            <button
+              onClick={() => onViewChange({ name: 'LEDGER' })}
+              className={getButtonClass(['LEDGER', 'VIEW_CLIENT_LEDGER_PDF', 'VIEW_COMPANY_LEDGER_PDF'])}
+            >
+              Ledger
+            </button>
              <button
               onClick={() => onViewChange({ name: 'SETTINGS' })}
               className={getButtonClass(['SETTINGS'])}


### PR DESCRIPTION
This commit addresses two issues related to the ledger feature:

1.  **Restores the 'Ledger' navigation button:**
    - The 'Ledger' button was missing from the main navigation bar in `components/Header.tsx`, making the ledger page inaccessible.
    - This change adds the button back, allowing users to navigate to the ledger view.
    - The button is also configured to remain active when viewing the PDF export pages for the ledgers.

2.  **Improves PDF titles for ledgers:**
    - The titles within the generated PDFs for ledgers were not specific enough.
    - A new `reportTitle` prop has been added to the `LedgerPDF` component to allow for more descriptive titles (e.g., "Client Ledger for [Client Name]").
    - The `App.tsx` component has been updated to provide these new titles.
    - The unnecessary export of `LedgerView` from `LedgerPDF.tsx` has been removed.