### PR TITLE
Fix: Correct payment type for truck hiring notes

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -32,6 +32,7 @@ export enum THNStatus {
 export enum PaymentType {
     ADVANCE = 'Advance',
     RECEIPT = 'Receipt',
+    PAYMENT = 'Payment',
 }
 
 export enum PaymentMode {

--- a/components/THNPaymentForm.tsx
+++ b/components/THNPaymentForm.tsx
@@ -19,7 +19,7 @@ export const THNPaymentForm: React.FC<THNPaymentFormProps> = ({ truckHiringNote,
         truckHiringNoteId: truckHiringNote._id,
         amount: truckHiringNote.balancePayable,
         date: getCurrentDate(),
-        type: PaymentType.RECEIPT, // This might need to be 'Payable' or something else
+        type: PaymentType.PAYMENT,
         mode: PaymentMode.CASH,
         referenceNo: '',
         notes: '',

--- a/types.ts
+++ b/types.ts
@@ -32,6 +32,7 @@ export enum THNStatus {
 export enum PaymentType {
     ADVANCE = 'Advance',
     RECEIPT = 'Receipt',
+    PAYMENT = 'Payment',
 }
 
 export enum PaymentMode {


### PR DESCRIPTION
The 'add payment' button on the truck hiring page was creating payments with the incorrect type 'RECEIPT' instead of 'PAYMENT'. This was because the `THNPaymentForm` was hardcoded to use `PaymentType.RECEIPT`.

This commit fixes the issue by:
1.  Adding a new `PAYMENT` type to the `PaymentType` enum in both the frontend and backend `types.ts` files.
2.  Updating `THNPaymentForm.tsx` to use the new `PaymentType.PAYMENT`.

The backend `payment.ts` model and `paymentController.ts` did not require any changes as they are designed to handle new payment types dynamically.

Testing was performed by:
1.  Running the backend and frontend servers.
2.  Creating a new truck hiring note via the API.
3.  Creating a new payment for the truck hiring note with the `PAYMENT` type via the API, which was successful.