### PR TITLE
feat: Add navigation link to Ledger page

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -58,6 +58,12 @@ export const Header: React.FC<HeaderProps> = ({ view, onViewChange, onLogout }) 
               Pending Payments
             </button>
             <button
+              onClick={() => onViewChange({ name: 'LEDGER' })}
+              className={getButtonClass(['LEDGER'])}
+            >
+              Ledger
+            </button>
+            <button
               onClick={() => onViewChange({ name: 'CLIENTS' })}
               className={getButtonClass(['CLIENTS'])}
             >


### PR DESCRIPTION
This commit adds a navigation link to the Ledger page in the `Header.tsx` component. This was missing, which prevented users from accessing the ledger.