### PR TITLE
Fix "Add Payment" dropdown not updating

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -126,6 +126,8 @@ export interface Invoice {
   isRcm: boolean;
   isManualGst: boolean;
   status: InvoiceStatus;
+  paidAmount: number;
+  balanceDue: number;
 }
 
 export interface CompanyInfo {
@@ -178,5 +180,4 @@ export interface TruckHiringNote {
   specialInstructions?: string;
   status: THNStatus;
   paidAmount: number;
-  payments: Payment[];
 }


### PR DESCRIPTION
The "Add Payment" option in the dropdown menu on the Dashboard and Truck Hiring Notes list was not always enabled correctly. This was due to the payment status of invoices and truck hiring notes not being updated in real-time.

To fix this, I have moved the payment status calculation logic to the frontend. The `App.tsx` component now uses `useMemo` hooks to calculate the `paidAmount`, `balanceDue`, and `status` for each invoice and truck hiring note. This ensures that the payment information is always up-to-date, and the "Add Payment" option is now correctly displayed.