### PR TITLE
feat: Add LR and Invoice number range settings and custom LR number o…

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -1,7 +1,188 @@
-// This file re-exports shared types from the root for use in the backend.
-export type {
-  CompanyInfo,
-  InvoiceStatus,
-  LorryReceiptStatus,
-  GstPayableBy,
-} from '../../../types';
+export enum LorryReceiptStatus {
+  CREATED = 'Created',
+  IN_TRANSIT = 'In Transit',
+  DELIVERED = 'Delivered',
+  INVOICED = 'Invoiced',
+  PAID = 'Paid',
+}
+
+export enum GstPayableBy {
+  CONSIGNOR = 'Consignor',
+  CONSIGNEE = 'Consignee',
+  TRANSPORTER = 'Transporter',
+}
+
+export enum GstType {
+    CGST_SGST = 'CGST/SGST',
+    IGST = 'IGST',
+}
+
+export enum InvoiceStatus {
+    UNPAID = 'Unpaid',
+    PARTIALLY_PAID = 'Partially Paid',
+    PAID = 'Paid',
+}
+
+export enum THNStatus {
+    UNPAID = 'Unpaid',
+    PARTIALLY_PAID = 'Partially Paid',
+    PAID = 'Paid',
+}
+
+export enum PaymentType {
+    ADVANCE = 'Advance',
+    RECEIPT = 'Receipt',
+    PAYMENT = 'Payment',
+}
+
+export enum PaymentMode {
+    CASH = 'Cash',
+    CHEQUE = 'Cheque',
+    NEFT = 'NEFT',
+    RTGS = 'RTGS',
+    UPI = 'UPI',
+}
+
+export interface Customer {
+  _id: string;
+  name: string; // Legal Name of Business
+  tradeName?: string;
+  address: string;
+  state:string;
+  gstin?: string;
+  contactPerson?: string;
+  contactPhone?: string;
+  contactEmail?: string;
+}
+
+export interface Vehicle {
+  _id: string;
+  number: string;
+}
+
+export interface LorryReceipt {
+  _id: string;
+  lrNumber: number;
+  date: string;
+  reportingDate?: string;
+  deliveryDate?: string;
+  consignorId: string;
+  consignor?: Customer;
+  consigneeId: string;
+  consignee?: Customer;
+  vehicleId: string;
+  vehicle?: Vehicle;
+  from: string;
+  to: string;
+  packages: {
+    count: number;
+    packingMethod: string;
+    description: string;
+    actualWeight: number;
+    chargedWeight: number;
+  }[];
+  charges: {
+    freight: number;
+    aoc: number;
+    hamali: number;
+    bCh: number;
+    trCh: number;
+    detentionCh: number;
+  };
+  totalAmount: number;
+  eWayBillNo: string;
+  valueGoods: number;
+  gstPayableBy: GstPayableBy;
+  status: LorryReceiptStatus;
+  insurance: {
+      hasInsured: boolean;
+      company?: string;
+      policyNo?: string;
+      date?: string;
+      amount?: number;
+      risk?: string;
+  },
+  invoiceNo: string;
+  sealNo: string;
+}
+
+export interface Invoice {
+  _id: string;
+  invoiceNumber: number;
+  date: string;
+  customerId: string;
+  customer?: Customer;
+  lorryReceipts: LorryReceipt[];
+  totalAmount: number;
+  remarks: string;
+  gstType: GstType;
+  cgstRate: number;
+  sgstRate: number;
+  igstRate: number;
+  cgstAmount: number;
+  sgstAmount: number;
+  igstAmount: number;
+  grandTotal: number;
+  isRcm: boolean;
+  isManualGst: boolean;
+  status: InvoiceStatus;
+}
+
+export interface CompanyInfo {
+    name: string;
+    address: string;
+    state: string;
+    phone1: string;
+    phone2: string;
+    email: string;
+    website: string;
+    gstin: string;
+    pan: string;
+    bankName: string;
+    accountNumber: string;
+    ifsc: string;
+    // New fields for number ranges
+    lrNumberStart?: number;
+    lrNumberEnd?: number;
+    invoiceNumberStart?: number;
+    invoiceNumberEnd?: number;
+    allowCustomLr?: boolean;
+}
+
+export interface Payment {
+    _id:string;
+    invoiceId?: string;
+    invoice?: Invoice;
+    truckHiringNoteId?: string;
+    truckHiringNote?: TruckHiringNote;
+    customerId: string;
+    customer?: Customer;
+    date: string;
+    amount: number;
+    type: PaymentType;
+    mode: PaymentMode;
+    referenceNo?: string;
+    notes?: string;
+}
+
+export interface TruckHiringNote {
+  _id: string;
+  thnNumber: number;
+  date: string;
+  truckOwnerName: string;
+  truckNumber: string;
+  driverName: string;
+  driverLicense: string;
+  origin: string;
+  destination: string;
+  goodsType: string;
+  weight: number;
+  freight: number;
+  advancePaid: number;
+  balancePayable: number;
+  expectedDeliveryDate: string;
+  specialInstructions?: string;
+  status: THNStatus;
+  paidAmount: number;
+  payments: Payment[];
+}


### PR DESCRIPTION
…ption

This commit introduces several new features related to Lorry Receipt (LR) and Invoice numbering:

-   **Number Range Settings:** A new "Numbering" tab has been added to the Settings page. This allows users to define a custom starting and ending number for both LR and Invoice numbers.
-   **Custom LR Numbers:** An option has been added to the "Create New Lorry Receipt" form to allow users to enter a custom LR number manually. This option is only available if the "Allow Custom LR Numbers" setting is enabled.
-   **Create LR from Invoice Form:** A "Create New LR" button has been added to the "Create New Invoice" form. This button opens the `LorryReceiptForm` in a modal, allowing users to create a new LR (with a custom number, if desired) without leaving the invoice creation process. The newly created LR is then automatically selected in the invoice form.

Backend changes include:
-   Updated `CompanyInfo` type to store the new settings.
-   Updated `lorryReceiptController` and `invoiceController` to handle custom numbers, including validation against the defined range and duplicate checks.
-   Updated `sequence.ts` to include the logic for generating numbers within the defined range.

This commit also fixes the build by duplicating the shared types into the backend's own `types.ts` file. This resolves the module resolution issues that were causing the build to fail.